### PR TITLE
find user by username or email

### DIFF
--- a/agate-core/src/main/java/org/obiba/agate/security/AgateRealmFactory.java
+++ b/agate-core/src/main/java/org/obiba/agate/security/AgateRealmFactory.java
@@ -229,7 +229,13 @@ public class AgateRealmFactory {
 
   private SimpleAuthorizationInfo getUserFromAvailablePrincipal(PrincipalCollection principals, Collection principalsFromRealm) {
     if(principalsFromRealm != null && !principalsFromRealm.isEmpty()) {
-      User user = userService.findUser((String) (!CollectionUtils.isEmpty(principalsFromRealm) ? principalsFromRealm.iterator().next() : principals.getPrimaryPrincipal()));
+      String principal = (String) (!CollectionUtils.isEmpty(principalsFromRealm) ? principalsFromRealm.iterator().next() : principals.getPrimaryPrincipal());
+
+      User user = userService.findUser(principal);
+      if (user == null) {
+        user = userService.findActiveUserByEmail(principal);
+      }
+
       return new SimpleAuthorizationInfo(user == null
         ? Collections.emptySet()
         : ImmutableSet.<String>builder().add(user.getRole(), Roles.AGATE_USER.toString()).build());

--- a/agate-core/src/main/java/org/obiba/agate/security/AgateSuccessfulStrategy.java
+++ b/agate-core/src/main/java/org/obiba/agate/security/AgateSuccessfulStrategy.java
@@ -60,6 +60,8 @@ public class AgateSuccessfulStrategy extends AbstractAuthenticationStrategy {
       if (Strings.isNullOrEmpty(username)) username = info.getPrincipals().toString();
 
       User user = userService.findUser(username);
+      if (user == null) user = userService.findUserByEmail(username);
+
       if (user == null) throw new RuntimeException("User [" + username + "] does not exist.");
 
       if (!user.getRealm().equals(realm.getName())) {

--- a/agate-core/src/main/java/org/obiba/agate/security/SecurityManagerFactory.java
+++ b/agate-core/src/main/java/org/obiba/agate/security/SecurityManagerFactory.java
@@ -74,7 +74,8 @@ public class SecurityManagerFactory implements FactoryBean<SessionsSecurityManag
     CacheManager cacheManager,
     Set<Realm> realms,
     RealmConfigService realmConfigService,
-    UserService userService, AgateRealmFactory agateRealmFactory,
+    UserService userService,
+    AgateRealmFactory agateRealmFactory,
     EventBus eventBus) {
     this.cacheManager = cacheManager;
     this.realms = realms;


### PR DESCRIPTION
relates to #348 

The authentication mechanism will ultimately depend on the realm's configuration.

However, In the case of LdapRealm only one will be valid for the authentication is based on the user DN (substitution token is `{0}`).

In the case of JdbcRealm, because we are using `?` for substitution, there seem to be no way to make a query with more than one argument. See this snippet from its code:
```
ps = conn.prepareStatement(authenticationQuery);
ps.setString(1, username);
```

ActiveDirectoryRealm is the only one where it could work (uses `{0}` as substitution token and is a filter query).
