### PR TITLE
test before overriding joining user's groups

### DIFF
--- a/agate-core/src/main/java/org/obiba/agate/service/UserService.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/UserService.java
@@ -247,7 +247,13 @@ public class UserService {
         if (foundConfigs.size() == 1) {
           RealmConfig realmConfig = foundConfigs.get(0);
           user.setStatus(UserStatus.ACTIVE);
-          user.setGroups(realmConfig.getGroups());
+
+          if (user.getGroups() != null) {
+            user.getGroups().addAll(realmConfig.getGroups());
+          } else {
+            user.setGroups(realmConfig.getGroups());
+          }
+
         } else {
           user.setRealm(AgateRealm.AGATE_USER_REALM.getName());
         }


### PR DESCRIPTION
relates to discussion in #385 

drupal can add some configured user groups the the user on signup. For a user to use drupal and its functionalities (DAR, cart, etc), the group `mica-user` is a minimal requirement that drupal already fulfills.

On signup drupal always adds the `mica-user` group as well as some other groups configured by the drupal administrator.