### PR TITLE
work with a clone instead

### DIFF
--- a/agate-webapp/src/main/webapp/app/realm/components/realm-form/component.js
+++ b/agate-webapp/src/main/webapp/app/realm/components/realm-form/component.js
@@ -186,7 +186,8 @@
       if (ctrl.form.main.$valid && ctrl.form.realm.$valid) {
         ctrl.model.content = JSON.stringify(ctrl.realm.model);
 
-        (ctrl.model.id ? RealmConfigResource.save(ctrl.model).$promise : RealmsConfigResource.create(ctrl.model).$promise)
+        var copy = angular.copy(ctrl.model);
+        (copy.id ? RealmConfigResource.save(copy).$promise : RealmsConfigResource.create(copy).$promise)
           .then(function() {
             ctrl.onSave({});
           })


### PR DESCRIPTION
relates to #418 

problem is due to the fact that we must transform LocalizedString into arrays (they are objects originally) on save (form is already valid). it is most apparent on slower internet connections.