### PR TITLE
manage mail.smtp.ssl.protocols from spring mail properties

### DIFF
--- a/agate-core/src/main/java/org/obiba/agate/config/MailConfiguration.java
+++ b/agate-core/src/main/java/org/obiba/agate/config/MailConfiguration.java
@@ -49,6 +49,10 @@ public class MailConfiguration implements EnvironmentAware {
 
   private static final String PROP_TRANSPORT_PROTO = "mail.transport.protocol";
 
+  private static final String PROP_MAIL_PROTOCOLS = "mail.smtp.ssl.protocols";
+
+  private static final String DEFAULT_PROP_MAIL_PROTOCOLS = "TLSv1.2";
+
   private static final Logger log = LoggerFactory.getLogger(MailConfiguration.class);
 
   private Environment environment;
@@ -72,6 +76,9 @@ public class MailConfiguration implements EnvironmentAware {
     Boolean tls = environment.getProperty(String.format("%s.%s", ENV_SPRING_MAIL, PROP_TLS), Boolean.class, false);
     Boolean auth = environment.getProperty(String.format("%s.%s", ENV_SPRING_MAIL, PROP_AUTH), Boolean.class, false);
 
+    // https://docs.spring.io/spring-boot/docs/2.7.8/reference/html/application-properties.html#application-properties.mail.spring.mail.properties
+    String mailProtocols = environment.getProperty(String.format("%s.%s", ENV_SPRING_MAIL + ".properties", PROP_MAIL_PROTOCOLS), DEFAULT_PROP_MAIL_PROTOCOLS);
+
     JavaMailSenderImpl sender = new JavaMailSenderImpl();
     if(host != null && !host.isEmpty()) {
       sender.setHost(host);
@@ -88,6 +95,11 @@ public class MailConfiguration implements EnvironmentAware {
     sendProperties.setProperty(PROP_SMTP_AUTH, auth.toString());
     sendProperties.setProperty(PROP_STARTTLS, tls.toString());
     sendProperties.setProperty(PROP_TRANSPORT_PROTO, protocol);
+    
+    if (tls) {
+      sendProperties.setProperty(PROP_MAIL_PROTOCOLS, mailProtocols);
+    }
+
     sender.setJavaMailProperties(sendProperties);
     return sender;
   }

--- a/agate-core/src/main/java/org/obiba/agate/config/MailConfiguration.java
+++ b/agate-core/src/main/java/org/obiba/agate/config/MailConfiguration.java
@@ -95,11 +95,7 @@ public class MailConfiguration implements EnvironmentAware {
     sendProperties.setProperty(PROP_SMTP_AUTH, auth.toString());
     sendProperties.setProperty(PROP_STARTTLS, tls.toString());
     sendProperties.setProperty(PROP_TRANSPORT_PROTO, protocol);
-    
-    if (tls) {
-      sendProperties.setProperty(PROP_MAIL_PROTOCOLS, mailProtocols);
-    }
-
+    sendProperties.setProperty(PROP_MAIL_PROTOCOLS, mailProtocols);
     sender.setJavaMailProperties(sendProperties);
     return sender;
   }


### PR DESCRIPTION
Some mail properties can be added to [spring mail properties config](https://docs.spring.io/spring-boot/docs/2.7.8/reference/html/application-properties.html#application-properties.mail.spring.mail.properties)

Explicitly manage `mail.smtp.ssl.protocols` even though, [as of JDK8, tls1.2 is the default](https://blogs.oracle.com/java/post/jdk-8-will-use-tls-12-as-default)