### PR TITLE
feat: added application realm-groups

### DIFF
--- a/agate-core/src/main/java/org/obiba/agate/domain/Application.java
+++ b/agate-core/src/main/java/org/obiba/agate/domain/Application.java
@@ -12,6 +12,7 @@ package org.obiba.agate.domain;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -40,7 +41,7 @@ public class Application extends AbstractAuditableDocument {
 
   private boolean autoApproval = true;
 
-  private Map<String, String> realmGroups = new HashMap<>();
+  private Map<String, List<String>> realmGroups = new HashMap<>();
 
   public Application() {
   }
@@ -105,20 +106,20 @@ public class Application extends AbstractAuditableDocument {
     this.redirectURI = redirectURI;
   }
 
-  public Map<String, String> getRealmGroups() {
+  public Map<String, List<String>> getRealmGroups() {
     return realmGroups != null ? realmGroups : new HashMap<>();
   }
 
-  public void setRealmGroups(Map<String, String> realmGroups) {
+  public void setRealmGroups(Map<String, List<String>> realmGroups) {
     this.realmGroups = realmGroups;
   }
 
-  public boolean hasRealmGroup(String realm) {
-    return getRealmGroups().containsKey(realm) && !Strings.isNullOrEmpty(getRealmGroups().get(realm));
+  public boolean hasRealmGroups(String realm) {
+    return getRealmGroups().containsKey(realm) && !getRealmGroups().get(realm).isEmpty();
   }
 
   public Iterable<String> getRealmGroups(String realm) {
-    return Splitter.on(",").trimResults().split(getRealmGroups().get(realm));
+    return hasRealmGroups(realm) ? ImmutableList.copyOf(getRealmGroups().get(realm)) : ImmutableList.of();
   }
 
   public void addRealmGroup(String realm, String group) {
@@ -126,7 +127,10 @@ public class Application extends AbstractAuditableDocument {
     if (realmGroups == null) {
       realmGroups = new HashMap<>();
     }
-    realmGroups.put(realm, group);
+    if (!realmGroups.containsKey(realm)) {
+      realmGroups.put(realm, Lists.newArrayList());
+    }
+    realmGroups.get(realm).add(group);
   }
 
 

--- a/agate-core/src/main/java/org/obiba/agate/domain/Application.java
+++ b/agate-core/src/main/java/org/obiba/agate/domain/Application.java
@@ -14,10 +14,9 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.obiba.mongodb.domain.AbstractAuditableDocument;
 import org.springframework.data.mongodb.core.index.Indexed;
-
-import jakarta.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.List;
@@ -118,16 +117,16 @@ public class Application extends AbstractAuditableDocument {
     return getRealmGroups().containsKey(realm) && !Strings.isNullOrEmpty(getRealmGroups().get(realm));
   }
 
-  public String getRealmGroup(String realm) {
-    return getRealmGroups().get(realm);
+  public Iterable<String> getRealmGroups(String realm) {
+    return Splitter.on(",").trimResults().split(getRealmGroups().get(realm));
   }
 
-  public Application addRealmGroup(String realm, String group) {
+  public void addRealmGroup(String realm, String group) {
+    if (Strings.isNullOrEmpty(realm) || Strings.isNullOrEmpty(group)) return;
     if (realmGroups == null) {
       realmGroups = new HashMap<>();
     }
     realmGroups.put(realm, group);
-    return this;
   }
 
 

--- a/agate-core/src/main/java/org/obiba/agate/domain/Application.java
+++ b/agate-core/src/main/java/org/obiba/agate/domain/Application.java
@@ -18,13 +18,14 @@ import org.obiba.mongodb.domain.AbstractAuditableDocument;
 import org.springframework.data.mongodb.core.index.Indexed;
 
 import jakarta.annotation.Nullable;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class Application extends AbstractAuditableDocument {
-
-  private static final long serialVersionUID = 4710884170897922907L;
 
   @Nonnull
   @Indexed(unique = true)
@@ -39,6 +40,8 @@ public class Application extends AbstractAuditableDocument {
   private List<Scope> scopes;
 
   private boolean autoApproval = true;
+
+  private Map<String, String> realmGroups = new HashMap<>();
 
   public Application() {
   }
@@ -102,6 +105,31 @@ public class Application extends AbstractAuditableDocument {
   public void setRedirectURI(String redirectURI) {
     this.redirectURI = redirectURI;
   }
+
+  public Map<String, String> getRealmGroups() {
+    return realmGroups != null ? realmGroups : new HashMap<>();
+  }
+
+  public void setRealmGroups(Map<String, String> realmGroups) {
+    this.realmGroups = realmGroups;
+  }
+
+  public boolean hasRealmGroup(String realm) {
+    return getRealmGroups().containsKey(realm) && !Strings.isNullOrEmpty(getRealmGroups().get(realm));
+  }
+
+  public String getRealmGroup(String realm) {
+    return getRealmGroups().get(realm);
+  }
+
+  public Application addRealmGroup(String realm, String group) {
+    if (realmGroups == null) {
+      realmGroups = new HashMap<>();
+    }
+    realmGroups.put(realm, group);
+    return this;
+  }
+
 
   public boolean hasScopes() {
     return scopes != null && !scopes.isEmpty();

--- a/agate-core/src/main/java/org/obiba/agate/domain/Group.java
+++ b/agate-core/src/main/java/org/obiba/agate/domain/Group.java
@@ -27,8 +27,6 @@ import java.util.Set;
 @Document(collection = "userGroup") // group is a reserved word in mongodb
 public class Group extends AbstractAuditableDocument {
 
-  private static final long serialVersionUID = -2028848270265682755L;
-
   @Indexed(unique = true)
   private String name;
 

--- a/agate-core/src/main/java/org/obiba/agate/domain/User.java
+++ b/agate-core/src/main/java/org/obiba/agate/domain/User.java
@@ -32,8 +32,6 @@ import java.util.Set;
 @Document
 public class User extends AbstractAuditableDocument {
 
-  private static final long serialVersionUID = 688200108221675323L;
-
   @Indexed(unique = true)
   private String name;
 
@@ -228,6 +226,14 @@ public class User extends AbstractAuditableDocument {
 
   public void setGroups(Set<String> groups) {
     this.groups = groups;
+  }
+
+  public void addGroups(Set<String> groupsToAdd) {
+    if (groupsToAdd == null) return;
+    if (this.groups == null) {
+      this.groups = Sets.newHashSet();
+    }
+    this.groups.addAll(groupsToAdd);
   }
 
   public Set<String> getApplications() {

--- a/agate-core/src/main/java/org/obiba/agate/service/GroupService.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/GroupService.java
@@ -50,7 +50,6 @@ public class GroupService {
     return groupRepository.findOneByName(name);
   }
 
-  @Nullable
   public List<Group> findByApplication(@Nonnull String application) {
     Assert.notNull(application, "Application name cannot be null.");
     return groupRepository.findByApplications(application);

--- a/agate-core/src/main/java/org/obiba/agate/service/RealmConfigService.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/RealmConfigService.java
@@ -32,6 +32,8 @@ public class RealmConfigService {
 
   private final GroupService groupService;
 
+  private final ApplicationService applicationService;
+
   private final EventBus eventBus;
 
   @Inject
@@ -39,10 +41,12 @@ public class RealmConfigService {
     RealmConfigRepository realmConfigRepository,
     UserRepository userRepository,
     GroupService groupService,
+    ApplicationService applicationService,
     EventBus eventBus) {
     this.realmConfigRepository = realmConfigRepository;
     this.userRepository = userRepository;
     this.groupService = groupService;
+    this.applicationService = applicationService;
     this.eventBus = eventBus;
   }
 
@@ -100,14 +104,16 @@ public class RealmConfigService {
 
   public List<RealmConfig> findAllRealmsForSignupAndApplication(String application) {
     if (Strings.isNullOrEmpty(application)) return Lists.newArrayList();
-    List<String> groupsForAppication = groupService.findByApplication(application)
+    List<String> groupsForApplication = groupService.findByApplication(application)
       .stream()
       .map(Group::getName)
-      .collect(Collectors.toList());
+      .toList();
+
+    Application app = applicationService.findByIdOrName(application);
 
     return realmConfigRepository.findAllByStatusAndForSignupTrue(RealmStatus.ACTIVE)
       .stream()
-      .filter(realmConfig -> realmConfig.getGroups().stream().anyMatch(groupsForAppication::contains))
+      .filter(realmConfig -> app.hasRealmGroup(realmConfig.getName()) || realmConfig.getGroups().stream().anyMatch(groupsForApplication::contains))
       .collect(Collectors.toList());
   }
 
@@ -137,12 +143,14 @@ public class RealmConfigService {
       .map(Group::getName)
       .toList();
 
+    Application app = applicationService.findByName(application);
+
     List<RealmConfig> realmConfigs = RealmUsage.ALL == usage
       ? realmConfigRepository.findAllByStatusAndType(status, agateRealm.name())
       : realmConfigRepository.findAllByStatusAndTypeAndForSignupTrue(status, agateRealm.name());
 
     return realmConfigs.stream()
-      .filter(realmConfig -> realmConfig.getGroups().stream().anyMatch(groupsForApplication::contains))
+      .filter(realmConfig -> app.hasRealmGroup(realmConfig.getName()) || realmConfig.getGroups().stream().anyMatch(groupsForApplication::contains))
       .collect(Collectors.toList());
   }
 

--- a/agate-core/src/main/java/org/obiba/agate/service/RealmConfigService.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/RealmConfigService.java
@@ -104,12 +104,15 @@ public class RealmConfigService {
 
   public List<RealmConfig> findAllRealmsForSignupAndApplication(String application) {
     if (Strings.isNullOrEmpty(application)) return Lists.newArrayList();
+    Application app = applicationService.findByIdOrName(application);
+    if (app == null) {
+      return Lists.newArrayList();
+    }
+
     List<String> groupsForApplication = groupService.findByApplication(application)
       .stream()
       .map(Group::getName)
       .toList();
-
-    Application app = applicationService.findByIdOrName(application);
 
     return realmConfigRepository.findAllByStatusAndForSignupTrue(RealmStatus.ACTIVE)
       .stream()
@@ -136,14 +139,16 @@ public class RealmConfigService {
                                                                         RealmStatus status,
                                                                         AgateRealm agateRealm,
                                                                         String application) {
-
     if (Strings.isNullOrEmpty(application)) return Lists.newArrayList();
+    Application app = applicationService.findByIdOrName(application);
+    if (app == null) {
+      return Lists.newArrayList();
+    }
+
     List<String> groupsForApplication = groupService.findByApplication(application)
       .stream()
       .map(Group::getName)
       .toList();
-
-    Application app = applicationService.findByName(application);
 
     List<RealmConfig> realmConfigs = RealmUsage.ALL == usage
       ? realmConfigRepository.findAllByStatusAndType(status, agateRealm.name())

--- a/agate-core/src/main/java/org/obiba/agate/service/RealmConfigService.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/RealmConfigService.java
@@ -113,7 +113,7 @@ public class RealmConfigService {
 
     return realmConfigRepository.findAllByStatusAndForSignupTrue(RealmStatus.ACTIVE)
       .stream()
-      .filter(realmConfig -> app.hasRealmGroup(realmConfig.getName()) || realmConfig.getGroups().stream().anyMatch(groupsForApplication::contains))
+      .filter(realmConfig -> app.hasRealmGroups(realmConfig.getName()) || realmConfig.getGroups().stream().anyMatch(groupsForApplication::contains))
       .collect(Collectors.toList());
   }
 
@@ -150,7 +150,7 @@ public class RealmConfigService {
       : realmConfigRepository.findAllByStatusAndTypeAndForSignupTrue(status, agateRealm.name());
 
     return realmConfigs.stream()
-      .filter(realmConfig -> app.hasRealmGroup(realmConfig.getName()) || realmConfig.getGroups().stream().anyMatch(groupsForApplication::contains))
+      .filter(realmConfig -> app.hasRealmGroups(realmConfig.getName()) || realmConfig.getGroups().stream().anyMatch(groupsForApplication::contains))
       .collect(Collectors.toList());
   }
 

--- a/agate-core/src/main/java/org/obiba/agate/service/UserService.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/UserService.java
@@ -274,6 +274,7 @@
             RealmConfig realmConfig = foundConfigs.get(0);
             user.setStatus(UserStatus.ACTIVE);
 
+            user.addGroups(Sets.newHashSet(realmConfig.getGroups()));
             if (user.getGroups() != null) {
               user.getGroups().addAll(realmConfig.getGroups());
             } else {

--- a/agate-core/src/main/java/org/obiba/agate/service/UserService.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/UserService.java
@@ -273,13 +273,7 @@
           if (foundConfigs.size() == 1) {
             RealmConfig realmConfig = foundConfigs.get(0);
             user.setStatus(UserStatus.ACTIVE);
-
             user.addGroups(Sets.newHashSet(realmConfig.getGroups()));
-            if (user.getGroups() != null) {
-              user.getGroups().addAll(realmConfig.getGroups());
-            } else {
-              user.setGroups(Sets.newHashSet(realmConfig.getGroups()));
-            }
           } else {
             user.setRealm(AgateRealm.AGATE_USER_REALM.getName());
           }

--- a/agate-core/src/main/java/org/obiba/agate/web/model/ApplicationDtos.java
+++ b/agate-core/src/main/java/org/obiba/agate/web/model/ApplicationDtos.java
@@ -35,6 +35,12 @@ class ApplicationDtos {
 
     builder.setAutoApproval(application.isAutoApproval());
 
+    if (!application.getRealmGroups().isEmpty()) {
+      application.getRealmGroups().forEach((realm, group) -> {
+        builder.addRealmGroups(Agate.ApplicationDto.RealmGroupDto.newBuilder().setRealm(realm).setGroup(group).build());
+      });
+    }
+
     return builder.build();
   }
 
@@ -52,6 +58,12 @@ class ApplicationDtos {
     application.setScopes(dto.getScopesList().stream().map(this::fromDto).collect(Collectors.toList()));
 
     if (dto.hasAutoApproval()) application.setAutoApproval(dto.getAutoApproval());
+
+    if (dto.getRealmGroupsCount() > 0) {
+      dto.getRealmGroupsList().forEach(realmGroup -> {
+        application.addRealmGroup(realmGroup.getRealm(), realmGroup.getGroup());
+      });
+    }
 
     return application;
   }

--- a/agate-core/src/main/java/org/obiba/agate/web/model/ApplicationDtos.java
+++ b/agate-core/src/main/java/org/obiba/agate/web/model/ApplicationDtos.java
@@ -36,8 +36,8 @@ class ApplicationDtos {
     builder.setAutoApproval(application.isAutoApproval());
 
     if (!application.getRealmGroups().isEmpty()) {
-      application.getRealmGroups().forEach((realm, group) -> {
-        builder.addRealmGroups(Agate.ApplicationDto.RealmGroupDto.newBuilder().setRealm(realm).setGroup(group).build());
+      application.getRealmGroups().forEach((realm, groups) -> {
+        builder.addRealmGroups(Agate.ApplicationDto.RealmGroupsDto.newBuilder().setRealm(realm).addAllGroups(groups).build());
       });
     }
 
@@ -61,7 +61,11 @@ class ApplicationDtos {
 
     if (dto.getRealmGroupsCount() > 0) {
       dto.getRealmGroupsList().forEach(realmGroup -> {
-        application.addRealmGroup(realmGroup.getRealm(), realmGroup.getGroup());
+        if (realmGroup.getGroupsCount() > 0) {
+          realmGroup.getGroupsList().forEach(group -> {
+            application.addRealmGroup(realmGroup.getRealm(), group);
+          });
+        }
       });
     }
 

--- a/agate-rest/src/main/java/org/obiba/agate/web/rest/application/ApplicationResource.java
+++ b/agate-rest/src/main/java/org/obiba/agate/web/rest/application/ApplicationResource.java
@@ -11,6 +11,8 @@
 package org.obiba.agate.web.rest.application;
 
 import javax.inject.Inject;
+
+import com.google.common.collect.Maps;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PUT;
@@ -60,6 +62,8 @@ public class ApplicationResource {
     dto.getScopesList().forEach(s -> application.addScope(s.getName(), s.getDescription()));
     if (dto.hasKey()) application.setKey(applicationService.hashKey(dto.getKey()));
     if (dto.hasAutoApproval()) application.setAutoApproval(dto.getAutoApproval());
+    application.setRealmGroups(Maps.newHashMap());
+    dto.getRealmGroupsList().forEach((realmGroup) -> application.addRealmGroup(realmGroup.getRealm(), realmGroup.getGroup()));
 
     applicationService.save(application);
 

--- a/agate-rest/src/main/java/org/obiba/agate/web/rest/application/ApplicationResource.java
+++ b/agate-rest/src/main/java/org/obiba/agate/web/rest/application/ApplicationResource.java
@@ -63,7 +63,11 @@ public class ApplicationResource {
     if (dto.hasKey()) application.setKey(applicationService.hashKey(dto.getKey()));
     if (dto.hasAutoApproval()) application.setAutoApproval(dto.getAutoApproval());
     application.setRealmGroups(Maps.newHashMap());
-    dto.getRealmGroupsList().forEach((realmGroup) -> application.addRealmGroup(realmGroup.getRealm(), realmGroup.getGroup()));
+    dto.getRealmGroupsList().forEach((realmGroup) -> {
+      realmGroup.getGroupsList().forEach((group) -> {
+        application.addRealmGroup(realmGroup.getRealm(), group);
+      });
+    });
 
     applicationService.save(application);
 

--- a/agate-rest/src/main/java/org/obiba/agate/web/rest/user/UsersPublicResource.java
+++ b/agate-rest/src/main/java/org/obiba/agate/web/rest/user/UsersPublicResource.java
@@ -251,7 +251,7 @@ public class UsersPublicResource {
         else
           user.setStatus(UserStatus.PENDING);
         if (application.hasRealmGroup(userRealm)) {
-          user.addGroups(Sets.newHashSet(application.getRealmGroup(userRealm)));
+          user.addGroups(Sets.newHashSet(application.getRealmGroups(userRealm)));
         }
       } else {
         user.setStatus(UserStatus.PENDING);

--- a/agate-rest/src/main/java/org/obiba/agate/web/rest/user/UsersPublicResource.java
+++ b/agate-rest/src/main/java/org/obiba/agate/web/rest/user/UsersPublicResource.java
@@ -250,7 +250,7 @@ public class UsersPublicResource {
           user.setStatus(UserStatus.APPROVED);
         else
           user.setStatus(UserStatus.PENDING);
-        if (application.hasRealmGroup(userRealm)) {
+        if (application.hasRealmGroups(userRealm)) {
           user.addGroups(Sets.newHashSet(application.getRealmGroups(userRealm)));
         }
       } else {

--- a/agate-rest/src/main/java/org/obiba/agate/web/rest/user/UsersPublicResource.java
+++ b/agate-rest/src/main/java/org/obiba/agate/web/rest/user/UsersPublicResource.java
@@ -250,6 +250,9 @@ public class UsersPublicResource {
           user.setStatus(UserStatus.APPROVED);
         else
           user.setStatus(UserStatus.PENDING);
+        if (application.hasRealmGroup(userRealm)) {
+          user.addGroups(Sets.newHashSet(application.getRealmGroup(userRealm)));
+        }
       } else {
         user.setStatus(UserStatus.PENDING);
       }

--- a/agate-web-model/src/main/protobuf/Agate.proto
+++ b/agate-web-model/src/main/protobuf/Agate.proto
@@ -138,7 +138,10 @@ message ApplicationDto {
     required string name = 1;
     optional string description = 2;
   }
-
+  message RealmGroupDto {
+    required string realm = 1;
+    required string group = 2;
+  }
   optional string id = 1;
   required string name = 2;
   optional string key = 3;
@@ -147,6 +150,7 @@ message ApplicationDto {
   optional string redirectURI = 6;
   repeated ScopeDto scopes = 7;
   optional bool autoApproval = 8;
+  repeated RealmGroupDto realmGroups = 9;
 }
 
 message ConfirmForm {

--- a/agate-web-model/src/main/protobuf/Agate.proto
+++ b/agate-web-model/src/main/protobuf/Agate.proto
@@ -138,9 +138,9 @@ message ApplicationDto {
     required string name = 1;
     optional string description = 2;
   }
-  message RealmGroupDto {
+  message RealmGroupsDto {
     required string realm = 1;
-    required string group = 2;
+    repeated string groups = 2;
   }
   optional string id = 1;
   required string name = 2;
@@ -150,7 +150,7 @@ message ApplicationDto {
   optional string redirectURI = 6;
   repeated ScopeDto scopes = 7;
   optional bool autoApproval = 8;
-  repeated RealmGroupDto realmGroups = 9;
+  repeated RealmGroupsDto realmGroups = 9;
 }
 
 message ConfirmForm {

--- a/agate-webapp/src/main/java/org/obiba/agate/web/controller/SignController.java
+++ b/agate-webapp/src/main/java/org/obiba/agate/web/controller/SignController.java
@@ -161,7 +161,7 @@ public class SignController {
         boolean redirectIsValid = false;
         for (String appName : appNames) {
           Application application = applicationService.findByIdOrName(appName);
-          if (application != null && application.getRedirectURIs().stream().noneMatch(postLogoutRedirectUri::startsWith)) {
+          if (application != null && application.getRedirectURIs().stream().anyMatch(postLogoutRedirectUri::startsWith)) {
             redirectIsValid = true;
             break;
           }

--- a/agate-webapp/src/main/resources/i18n/en.json
+++ b/agate-webapp/src/main/resources/i18n/en.json
@@ -167,7 +167,7 @@
     },
     "messages": {
       "success": "<strong>Session invalidated!</strong>",
-      "error": "<strong>An error has occured!</strong> The session could not be invalidated."
+      "error": "<strong>An error has occurred!</strong> The session could not be invalidated."
     }
   },
   "errors": {
@@ -287,6 +287,8 @@
     "redirectURI-help": "Callback URL to the application's server, required in the OAuth context. Use commas to separate multiple allowed callback URLs.",
     "autoApproval": "User Approved on Sign up",
     "autoApproval-help": "Automatically approve a user who signed up through the application. Otherwise the user will be in 'pending for approval' state, requiring manual action.",
+    "realmGroups": "Realms and groups",
+    "realmGroups-help": "Mapping between realm and group names. When defined, corresponding realms will be proposed for user signin/signup from the application. When a user joins though an application, using a realm, the corresponding group(s) will be automatically applied.",
     "confirmKey": "Confirm key",
     "changeKey": "Change Key",
     "delete-dialog": {
@@ -304,6 +306,14 @@
       "name-help": "Name of the permission, without spaces.",
       "description": "Description",
       "description-help": "Short description of the requested permission that will be shown to the user."
+    },
+    "realm-group": {
+      "add": "Add Realm-Group",
+      "edit": "Edit Realm-Group",
+      "realm": "Realm",
+      "realm-help": "A realm name.",
+      "group": "Group",
+      "group-help": "A group name (or comma separated group names), which members have access to the application. This group (or groups) will be applied to realm's users who join through this application."
     }
   },
   "groups": "Groups",

--- a/agate-webapp/src/main/resources/i18n/en.json
+++ b/agate-webapp/src/main/resources/i18n/en.json
@@ -308,12 +308,12 @@
       "description-help": "Short description of the requested permission that will be shown to the user."
     },
     "realm-group": {
-      "add": "Add Realm-Group",
-      "edit": "Edit Realm-Group",
+      "add": "Add Realm-Groups",
+      "edit": "Edit Realm-Groups",
       "realm": "Realm",
       "realm-help": "A realm name.",
-      "group": "Group",
-      "group-help": "A group name (or comma separated group names), which members have access to the application. This group (or groups) will be applied to realm's users who join through this application."
+      "group": "Groups",
+      "group-help": "One or more groups, which members have access to the application. This group (or groups) will be applied to realm's users who join through this application."
     }
   },
   "groups": "Groups",

--- a/agate-webapp/src/main/resources/i18n/fr.json
+++ b/agate-webapp/src/main/resources/i18n/fr.json
@@ -308,12 +308,12 @@
       "description-help": "Description courte de la permission qui sera affichée à l'utilisateur."
     },
     "realm-group": {
-      "add": "Ajouter un domaine-groupe",
-      "edit": "Modification du un domaine-groupe",
+      "add": "Ajouter un domaine-groupes",
+      "edit": "Modification du domaine-groupes",
       "realm": "Domaine",
       "realm-help": "Un nom de domaine.",
       "group": "Groupe",
-      "group-help": "Un nom de groupe (ou plusieurs, séparés par des virgules), dont les membres ont accès à l'application. Ce(s) groupe(s) sera(ont) appliqué(s) automatiquement quand un utilisateur de ce domaine s'enregistre."
+      "group-help": "Un ou plusieurs groupes, dont les membres ont accès à l'application. Ce(s) groupe(s) sera(ont) appliqué(s) automatiquement quand un utilisateur de ce domaine s'enregistre."
     }
   },
   "groups": "Groupes",

--- a/agate-webapp/src/main/resources/i18n/fr.json
+++ b/agate-webapp/src/main/resources/i18n/fr.json
@@ -287,6 +287,8 @@
     "redirectURI-help": "L'URL de rappel au serveur d'application, requise dans le context d'OAuth. Utiliser des virgules pour spécifier plusieurs URL autorisées.",
     "autoApproval": "Approuver les utilisateurs nouvellement inscrits",
     "autoApproval-help": "Approuver automatiquement les utilisateurs s'étant inscrits par l'application. Sinon l'utilisateur sera en attente d'approbation, nécessitant une intervention manuelle.",
+    "realmGroups": "Domaines et groupes",
+    "realmGroups-help": "Association entre noms de domaine et de groupe(s). Quand défini, les domaines correspondant seront proposés à l'identification des utilisateurs pour cette application. D'autre part le(s) groupe(s) du domaine utilisé pour créé un compte pour une application sera automatiquement appliqué.",
     "confirmKey": "Confirmer la clé",
     "changeKey": "Changer la clé",
     "delete-dialog": {
@@ -304,6 +306,14 @@
       "name-help": "Nom de la permission, sans espace.",
       "description": "Description",
       "description-help": "Description courte de la permission qui sera affichée à l'utilisateur."
+    },
+    "realm-group": {
+      "add": "Ajouter un domaine-groupe",
+      "edit": "Modification du un domaine-groupe",
+      "realm": "Domaine",
+      "realm-help": "Un nom de domaine.",
+      "group": "Groupe",
+      "group-help": "Un nom de groupe (ou plusieurs, séparés par des virgules), dont les membres ont accès à l'application. Ce(s) groupe(s) sera(ont) appliqué(s) automatiquement quand un utilisateur de ce domaine s'enregistre."
     }
   },
   "groups": "Groupes",

--- a/agate-webapp/src/main/webapp/app/application/application-controller.js
+++ b/agate-webapp/src/main/webapp/app/application/application-controller.js
@@ -76,7 +76,7 @@ agate.application
           controller: 'ApplicationRealmGroupModalController',
           resolve: {
             'realmGroup': function () {
-               return angular.copy(rg);
+               return rg ? angular.copy(rg) : {};
             }
           }
         }).result.then(function (realmGroup) {
@@ -235,10 +235,18 @@ agate.application
       };
     }])
 
-    .controller('ApplicationRealmGroupModalController', ['$scope', '$filter', '$uibModalInstance', 'realmGroup',
-      function($scope, $filter, $uibModalInstance, realmGroup) {
+    .controller('ApplicationRealmGroupModalController', ['$scope', '$filter', '$uibModalInstance', 'GroupsResource', 'realmGroup',
+      function($scope, $filter, $uibModalInstance, GroupsResource, realmGroup) {
         $scope.editMode = realmGroup && realmGroup.realm;
         $scope.realmGroup = realmGroup;
+        if (!$scope.realmGroup.groups) {
+          $scope.realmGroup.groups = [];
+        }
+
+        $scope.groupList = [];
+        GroupsResource.query().$promise.then((groups) => {
+          $scope.groupList = groups.map((grp) => grp.name);
+        });
 
         $scope.save = function (form) {
           if (!form.$valid) {

--- a/agate-webapp/src/main/webapp/app/application/application-controller.js
+++ b/agate-webapp/src/main/webapp/app/application/application-controller.js
@@ -70,6 +70,48 @@ agate.application
     function ($scope, $location, $routeParams, ApplicationResource, $uibModal, $log) {
       $scope.application = $routeParams.id ? ApplicationResource.get({id: $routeParams.id}) : {};
 
+      $scope.editRealmGroup = function (rg) {
+        $uibModal.open({
+          templateUrl: 'app/application/views/application-realm-group-modal-form.html',
+          controller: 'ApplicationRealmGroupModalController',
+          resolve: {
+            'realmGroup': function () {
+               return angular.copy(rg);
+            }
+          }
+        }).result.then(function (realmGroup) {
+          var onSuccess = function () {
+            $scope.status = $scope.statusCodes.SUCCESS;
+            $location.path('/application' + ($scope.application.id ? '/' + $scope.application.id : '')).replace();
+          };
+
+          var onError = function() {
+            $log.debug('DEBUG', $scope, $scope.$parent);
+            $scope.status = $scope.statusCodes.ERROR;
+          };
+
+          if(!$scope.application.realmGroups) {
+            $scope.application.realmGroups = [];
+          }
+
+          var idx = $scope.application.realmGroups.findIndex((val) => val.realm === realmGroup.realm);
+          if(idx > -1) {
+            $scope.application.realmGroups[idx] = realmGroup;
+          } else {
+            $scope.application.realmGroups.push(realmGroup);
+          }
+          ApplicationResource.update({id: $scope.application.id}, $scope.application, onSuccess, onError);
+        });
+      };
+
+      $scope.deleteRealmGroup = function(rg) {
+        var idx = $scope.application.realmGroups.indexOf(rg);
+        if(idx > -1) {
+          $scope.application.realmGroups.splice(idx, 1);
+          ApplicationResource.update({id: $scope.application.id}, $scope.application);
+         }
+      };
+
       $scope.editScope = function (scp) {
         $uibModal.open({
           templateUrl: 'app/application/views/application-scope-modal-form.html',
@@ -191,4 +233,23 @@ agate.application
       $scope.cancel = function () {
         $uibModalInstance.dismiss('cancel');
       };
-    }]);
+    }])
+
+    .controller('ApplicationRealmGroupModalController', ['$scope', '$filter', '$uibModalInstance', 'realmGroup',
+      function($scope, $filter, $uibModalInstance, realmGroup) {
+        $scope.editMode = realmGroup && realmGroup.realm;
+        $scope.realmGroup = realmGroup;
+
+        $scope.save = function (form) {
+          if (!form.$valid) {
+            form.saveAttempted = true;
+            return;
+          }
+
+          $uibModalInstance.close($scope.realmGroup);
+        };
+
+        $scope.cancel = function () {
+          $uibModalInstance.dismiss('cancel');
+        };
+      }]);

--- a/agate-webapp/src/main/webapp/app/application/views/application-realm-group-modal-form.html
+++ b/agate-webapp/src/main/webapp/app/application/views/application-realm-group-modal-form.html
@@ -1,0 +1,45 @@
+<!--
+  ~ Copyright (c) 2024 OBiBa. All rights reserved.
+  ~
+  ~ This program and the accompanying materials
+  ~ are made available under the terms of the GNU Public License v3.0.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<div class="modal-content">
+  <form name="form" role="form" novalidate ng-submit="save(form)">
+
+    <div class="modal-header">
+      <button type="button" class="close" aria-hidden="true" ng-click="cancel()">&times;</button>
+      <h4 class="modal-title" id="myAttributeModal">
+        <span ng-if="!editMode" translate>application.realm-group.add</span>
+        <span ng-if="editMode" translate>application.realm-group.edit</span>
+      </h4>
+    </div>
+
+    <div class="modal-body">
+
+      <p class="alert alert-danger" ng-show="form.saveAttempted && form.$invalid" translate="">fix-error</p>
+
+      <div form-input name="realm" model="realmGroup.realm" label="application.realm-group.realm" help="application.realm-group.realm-help"
+          required="true" disabled="editMode"></div>
+
+      <div form-input name="group" model="realmGroup.group" label="application.realm-group.group"
+           required="true" help="application.realm-group.group-help"></div>
+
+    </div>
+
+    <div class="modal-footer">
+      <button type="button" class="btn btn-default" ng-click="cancel()">
+        <span translate>cancel</span>
+      </button>
+      <button type="submit" class="btn btn-primary">
+        <span translate>save</span>
+      </button>
+    </div>
+
+  </form>
+
+</div>

--- a/agate-webapp/src/main/webapp/app/application/views/application-realm-group-modal-form.html
+++ b/agate-webapp/src/main/webapp/app/application/views/application-realm-group-modal-form.html
@@ -26,8 +26,20 @@
       <div form-input name="realm" model="realmGroup.realm" label="application.realm-group.realm" help="application.realm-group.realm-help"
           required="true" disabled="editMode"></div>
 
-      <div form-input name="group" model="realmGroup.group" label="application.realm-group.group"
-           required="true" help="application.realm-group.group-help"></div>
+      <div class="form-group">
+        <label class="control-label">
+          <span translate>application.realm-group.group</span>
+        </label>
+        <ui-select multiple theme="bootstrap" ng-model="realmGroup.groups" reset-search-input="true">
+          <ui-select-match><span ng-bind-html="$select.selected[$index]"></span></ui-select-match>
+          <ui-select-choices repeat="group in groupList">
+            {{group}}
+          </ui-select-choices>
+        </ui-select>
+        <p class="help-block" translate>
+          application.realm-group.group-help
+        </p>
+      </div>
 
     </div>
 

--- a/agate-webapp/src/main/webapp/app/application/views/application-view.html
+++ b/agate-webapp/src/main/webapp/app/application/views/application-view.html
@@ -117,6 +117,49 @@
           </table>
         </div>
       </div>
+
+      <h3 translate>application.realmGroups</h3>
+      <p class="help-block">
+        <span translate>application.realmGroups-help</span>
+      </p>
+      <a href="" ng-click="editRealmGroup()" class="btn btn-info">
+        <i class="fa fa-plus"></i> <span translate>application.realm-group.add</span>
+      </a>
+
+      <div class="table-responsive">
+        <table class="table table-striped table-hover table-bordered"
+               ng-show="application.realmGroups && application.realmGroups.length > 0">
+          <thead>
+          <tr>
+            <th translate>application.realm-group.realm</th>
+            <th translate>application.realm-group.group</th>
+            <th translate>application.actions</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr dir-paginate="realmGroup in application.realmGroups | itemsPerPage: 20">
+            <td>
+              <code>{{realmGroup.realm}}</code>
+            </td>
+            <td>
+              {{realmGroup.group}}
+            </td>
+            <td>
+              <ul class="list-inline">
+                <li>
+                  <a href="" ng-click="editRealmGroup(realmGroup)" title="{{'edit' | translate}}"><i
+                          class="fa fa-pencil"></i></a>
+                </li>
+                <li>
+                  <a href="" ng-click="deleteRealmGroup(realmGroup)" title="{{'delete' | translate}}"><i
+                          class="fa fa-trash-o"></i></a>
+                </li>
+              </ul>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>

--- a/agate-webapp/src/main/webapp/app/application/views/application-view.html
+++ b/agate-webapp/src/main/webapp/app/application/views/application-view.html
@@ -142,7 +142,7 @@
               <code>{{realmGroup.realm}}</code>
             </td>
             <td>
-              {{realmGroup.group}}
+              {{realmGroup.groups.join(', ')}}
             </td>
             <td>
               <ul class="list-inline">


### PR DESCRIPTION
For a more application specific configuration, it is now possible to declare which realms can be used for each applicaiton. For each of this declared realm, the list of groups to apply when a user registers through the application is specified.

![image](https://github.com/user-attachments/assets/409aad5a-e809-492b-aac1-1db5da6926c5)

![image](https://github.com/user-attachments/assets/9e1f5ece-baa6-4bc9-9729-5628c988273c)
