### PR TITLE
chore(deps): update Java dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.1.0</version>
   </parent>
 
   <modules>
@@ -37,56 +37,55 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <assertj-core.version>3.27.7</assertj-core.version>
-    <awaitility.version>4.2.1</awaitility.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <awaitility.version>4.3.0</awaitility.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
     <cache-api.version>1.1.1</cache-api.version>
-    <commons-io.version>2.15.1</commons-io.version>
+    <commons-io.version>2.22.0</commons-io.version>
     <commons-lang.version>3.18.0</commons-lang.version>
-    <dropwizard-metrics.version>4.2.23</dropwizard-metrics.version>
-    <easymock.version>5.2.0</easymock.version>
+    <dropwizard-metrics.version>4.2.39</dropwizard-metrics.version>
+    <easymock.version>5.6.0</easymock.version>
     <ehcache.version>3.10.8</ehcache.version>
     <esapi.version>2.6.0.0</esapi.version>
-    <freemarker.version>2.3.33</freemarker.version>
-    <guava.version>33.2.1-jre</guava.version>
+    <freemarker.version>2.3.34</freemarker.version>
+    <guava.version>33.6.0-jre</guava.version>
     <javax.inject.version>1</javax.inject.version>
-    <jersey.version>3.1.3</jersey.version>
-    <jetty.version>12.1.6</jetty.version>
-    <jhipsterloaded.version>0.7</jhipsterloaded.version>
-    <jjwt.version>0.12.3</jjwt.version>
-    <joda-time.version>2.8.2</joda-time.version>
+    <jersey.version>3.1.12</jersey.version>
+    <jetty.version>12.1.11</jetty.version>
+    <jhipsterloaded.version>0.12</jhipsterloaded.version>
+    <jjwt.version>0.13.0</jjwt.version>
+    <joda-time.version>2.14.2</joda-time.version>
     <json-api.version>2.1.3</json-api.version>
-    <json-path.version>2.9.0</json-path.version>
-    <json-smart.version>2.4.9</json-smart.version>
-    <jsr305.version>3.0.0</jsr305.version>
-    <lang-tag.version>1.4.4</lang-tag.version>
-    <logback.version>1.5.35</logback.version>
+    <json-path.version>2.10.0</json-path.version>
+    <json-smart.version>2.6.0</json-smart.version>
+    <jsr305.version>3.0.2</jsr305.version>
+    <lang-tag.version>1.7</lang-tag.version>
+    <logback.version>1.6.0</logback.version>
     <logstash-logback.version>7.4</logstash-logback.version>
-    <mariabd.version>3.0.7</mariabd.version>
+    <mariabd.version>3.5.9</mariabd.version>
     <metrics-spring.version>3.0.0</metrics-spring.version>
-    <mongodb-driver.version>5.6.3</mongodb-driver.version>
-    <mysql.version>8.4.0</mysql.version>
-    <mysql-connector-j.version>8.4.0</mysql-connector-j.version>
-    <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
-    <nosqlunit.version>0.7.9</nosqlunit.version>
-    <oauth-oidc-sdk.version>11.12</oauth-oidc-sdk.version>
-    <obiba-commons.version>5.1.2</obiba-commons.version>
-    <parsson.version>1.1.5</parsson.version>
+    <mongodb.version>5.9.1</mongodb.version>
+    <mysql.version>9.7.0</mysql.version>
+    <mysql-connector-j.version>9.7.0</mysql-connector-j.version>
+    <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
+    <oauth-oidc-sdk.version>11.38.2</oauth-oidc-sdk.version>
+    <obiba-commons.version>5.2.0</obiba-commons.version>
+    <parsson.version>1.1.9</parsson.version>
     <postgres.version>42.7.12</postgres.version>
-    <protobuf.version>3.25.5</protobuf.version>
+    <protobuf.version>3.25.8</protobuf.version>
     <protobuf-java-format.version>1.2.1-obiba</protobuf-java-format.version>
-    <shiro.version>2.1.0</shiro.version>
-    <shiro-extras.version>1.1.0</shiro-extras.version>
+    <shiro.version>2.2.1</shiro.version>
+    <shiro-extras.version>2.0.0</shiro-extras.version>
     <totp.version>1.7.1</totp.version>
 
     <!-- maven plugins -->
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <github-release-plugin.version>1.6.0</github-release-plugin.version>
     <maven-assertj-generator-plugin.version>1.2.0</maven-assertj-generator-plugin.version>
-    <maven-dependency-plugin.version>3.1.0</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
-    <maven-enforcer-plugin.version>1.3.1</maven-enforcer-plugin.version>
+    <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
+    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+    <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-findbugs-plugin.version>3.0.4</maven-findbugs-plugin.version>
-    <maven-pmd-plugin.version>3.1</maven-pmd-plugin.version>
+    <maven-pmd-plugin.version>3.6</maven-pmd-plugin.version>
     <maven-sonar-plugin.version>2.2</maven-sonar-plugin.version>
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
     <rpm-maven-plugin.version>2.2.0</rpm-maven-plugin.version>
@@ -313,12 +312,6 @@
         <version>${jersey.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>mongodb-driver-sync</artifactId>
-        <version>${mongodb-driver.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Align managed dependency versions with obiba/opal's pom.xml where applicable (bouncycastle, commons-io, guava, jetty, joda-time, json-smart, jsr305, lang-tag, logback, mariadb, mongodb, mysql, nimbus-jose-jwt, oauth2-oidc-sdk, obiba-commons, protobuf, shiro, shiro-extras) and bump Spring Boot parent to 4.1.0 so Mongo driver artifacts stay consistent under Boot's own mongodb-driver-bom import.

Also bump several agate-only dependencies (awaitility, dropwizard-metrics, easymock, freemarker, jersey, jhipsterloaded, jjwt, json-path, parsson, maven-dependency-plugin, maven-enforcer-plugin) and remove the unused nosqlunit.version property.