### PR TITLE
fix: unbind subject from thread after OIDC callback

### DIFF
--- a/agate-webapp/src/main/java/org/obiba/agate/web/filter/auth/oidc/AgateCallbackFilter.java
+++ b/agate-webapp/src/main/java/org/obiba/agate/web/filter/auth/oidc/AgateCallbackFilter.java
@@ -116,10 +116,29 @@ public class AgateCallbackFilter extends OIDCCallbackFilter {
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    // The callback URL is not covered by org.obiba.shiro.web.filter.AuthenticationFilter (see
+    // org.obiba.shiro.authenticationFilter.requestPrefix), so nothing else will clean up the ThreadContext:
+    // both AuthenticationExecutor.login() and prepareSubjectSession() bind the authenticated subject to the
+    // executing thread and it must be restored here, otherwise the subject leaks to the next request served
+    // by that (pooled) thread.
+    Subject previousSubject = ThreadContext.getSubject();
     try {
       super.doFilterInternal(request, response, filterChain);
     } catch (OIDCException e) {
       sendRedirectOrSendError(makeErrorUrl(null), e.getMessage(), response);
+    } finally {
+      restoreSubject(previousSubject);
+    }
+  }
+
+  private void restoreSubject(Subject previousSubject) {
+    Subject currentSubject = ThreadContext.getSubject();
+    if (currentSubject == previousSubject) return;
+    log.trace("Unbinding subject {} from executing thread {}", currentSubject == null ? null : currentSubject.getPrincipal(), Thread.currentThread().getId());
+    if (previousSubject == null) {
+      ThreadContext.unbindSubject();
+    } else {
+      ThreadContext.bind(previousSubject);
     }
   }
 


### PR DESCRIPTION
The /auth/callback/* URL is not covered by
org.obiba.shiro.authenticationFilter.requestPrefix, so AuthenticationFilter short-circuits before its finally { unbind(); } and never cleans up the ThreadContext. Meanwhile the callback binds the subject twice (in AuthenticationExecutor.login() and in prepareSubjectSession()) and unbinds it zero times, leaking it onto the pooled request thread.

This surfaced as "Previous executing subject was not properly unbound from executing thread" on the next covered request, but also meant an intervening uncovered request could see the previous user's identity via SecurityUtils.getSubject().

Snapshot the bound subject before the callback runs and restore it in a finally block, symmetric with AuthenticationFilter.unbind().