### PR TITLE
fix: align jjwt artifact versions to avoid Jwts class init failure

### DIFF
--- a/agate-core/pom.xml
+++ b/agate-core/pom.xml
@@ -232,6 +232,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.obiba.commons</groupId>
       <artifactId>obiba-mongodb</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <jersey.version>3.1.12</jersey.version>
     <jetty.version>12.1.11</jetty.version>
     <jhipsterloaded.version>0.12</jhipsterloaded.version>
-    <jjwt.version>0.13.0</jjwt.version>
+    <jjwt.version>0.12.6</jjwt.version>
     <joda-time.version>2.14.2</joda-time.version>
     <json-api.version>2.1.3</json-api.version>
     <json-path.version>2.10.0</json-path.version>
@@ -522,6 +522,20 @@
         <groupId>io.jsonwebtoken</groupId>
         <artifactId>jjwt-api</artifactId>
         <version>${jjwt.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-impl</artifactId>
+        <version>${jjwt.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-jackson</artifactId>
+        <version>${jjwt.version}</version>
+        <scope>runtime</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
jjwt-api was managed at 0.13.0 while jjwt-impl and jjwt-jackson came in transitively from obiba-shiro at 0.12.6. The 0.13.0 Jwts static initializer reflectively loads DefaultJwtBuilder$Supplier, which does not exist in the 0.12.6 impl, so any token creation failed with NoClassDefFoundError: Could not initialize class io.jsonwebtoken.Jwts.

Pin jjwt.version back to 0.12.6 and manage jjwt-impl/jjwt-jackson explicitly (declared as runtime deps of agate-core) so api and impl can no longer drift apart on future dependency bumps.