### PR TITLE
fix: let protobuf provider write protobuf DTOs to JSON

### DIFF
--- a/agate-rest/pom.xml
+++ b/agate-rest/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>jersey-media-multipart</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/agate-rest/src/main/java/org/obiba/agate/web/rest/config/AgateJacksonJsonProvider.java
+++ b/agate-rest/src/main/java/org/obiba/agate/web/rest/config/AgateJacksonJsonProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.agate.web.rest.config;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.Providers;
+
+import com.google.protobuf.Message;
+import org.glassfish.jersey.jackson.internal.DefaultJacksonJaxbJsonProvider;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+/**
+ * Jackson JSON provider that leaves protobuf messages to {@link org.obiba.jersey.protobuf.ProtobufJsonProvider}.
+ * <p>
+ * Both providers declare {@code MessageBodyWriter<Object>} for {@code application/json}, so Jersey cannot tell them
+ * apart by type or media type distance and picks whichever comes first in an unordered provider set. When Jackson wins,
+ * writing a protobuf DTO fails with "Direct self-reference leading to cycle" on {@code UnknownFieldSet}. Declining
+ * protobuf types here makes the choice deterministic, whatever the provider order happens to be.
+ *
+ * @see JerseyConfiguration
+ */
+@Provider
+@Singleton
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+public class AgateJacksonJsonProvider extends DefaultJacksonJaxbJsonProvider {
+
+  @Inject
+  public AgateJacksonJsonProvider(@Context Providers providers, @Context Configuration config) {
+    super(providers, config);
+  }
+
+  @Override
+  public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return !isProtobuf(type, genericType) && super.isReadable(type, genericType, annotations, mediaType);
+  }
+
+  @Override
+  public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return !isProtobuf(type, genericType) && super.isWriteable(type, genericType, annotations, mediaType);
+  }
+
+  /**
+   * A protobuf message, or a collection/array of protobuf messages, as accepted by ProtobufJsonProvider.
+   */
+  private static boolean isProtobuf(Class<?> type, Type genericType) {
+    if (Message.class.isAssignableFrom(type)) return true;
+    if (type.isArray()) return Message.class.isAssignableFrom(type.getComponentType());
+    if (!Iterable.class.isAssignableFrom(type)) return false;
+    if (genericType instanceof ParameterizedType) {
+      Type[] arguments = ((ParameterizedType) genericType).getActualTypeArguments();
+      return arguments.length == 1 && arguments[0] instanceof Class
+        && Message.class.isAssignableFrom((Class<?>) arguments[0]);
+    }
+    return false;
+  }
+}

--- a/agate-rest/src/main/java/org/obiba/agate/web/rest/config/JerseyConfiguration.java
+++ b/agate-rest/src/main/java/org/obiba/agate/web/rest/config/JerseyConfiguration.java
@@ -11,13 +11,14 @@
 package org.obiba.agate.web.rest.config;
 
 import jakarta.ws.rs.ApplicationPath;
+import org.glassfish.jersey.internal.InternalProperties;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.base.JsonMappingExceptionMapper;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.base.JsonParseExceptionMapper;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.spring.scope.RequestContextFilter;
 import org.obiba.agate.config.Constants;
 import org.obiba.agate.web.rest.security.*;
-import org.obiba.jersey.protobuf.ProtobufJsonProvider;
-import org.obiba.jersey.protobuf.ProtobufNativeProvider;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
@@ -34,15 +35,16 @@ public class JerseyConfiguration extends ResourceConfig {
   public JerseyConfiguration(Environment environment, CSRFTokenHelper csrfTokenHelper) {
     register(RequestContextFilter.class);
     packages("org.obiba.agate.web", "org.obiba.jersey");
-    // Explicitly register the protobuf message body providers so they are treated as "custom" providers.
-    // Since Jersey 3.1.12 / Spring Boot 4.1, the auto-discovered Jackson provider (DefaultJacksonJaxbJsonProvider)
-    // and the package-scanned ProtobufJsonProvider both declare MessageBodyWriter<Object> for application/json,
-    // so Jersey's WorkerComparator breaks the tie on the isCustom() flag. Registering the protobuf providers here
-    // marks them custom, ensuring they win over the (non-custom) Jackson provider for protobuf Message types, while
-    // Jackson still handles plain POJO/Map JSON responses. Without this, serializing protobuf DTOs to JSON fails with
-    // "Direct self-reference leading to cycle" (protobuf UnknownFieldSet), surfacing as HTTP 400 on the admin UI.
-    register(ProtobufJsonProvider.class);
-    register(ProtobufNativeProvider.class);
+    // Opt out of JacksonFeature's auto-registered DefaultJacksonJaxbJsonProvider and use AgateJacksonJsonProvider
+    // instead: it does the same job but declines protobuf messages, which are the ProtobufJsonProvider's business.
+    // Both providers declare MessageBodyWriter<Object> for application/json, so Jersey cannot order them by type or
+    // media type distance and picks whichever comes first in an unordered set. When Jackson wins, writing a protobuf
+    // DTO fails with "Direct self-reference leading to cycle" (UnknownFieldSet) and the response turns into an error.
+    property(InternalProperties.JSON_FEATURE, AgateJacksonJsonProvider.class.getSimpleName());
+    register(AgateJacksonJsonProvider.class);
+    // exception mappers JacksonFeature would have registered along with its provider
+    register(JsonParseExceptionMapper.class);
+    register(JsonMappingExceptionMapper.class);
     register(ReAuthInterceptor.class);
     register(AuthenticationInterceptor.class);
     register(AuditInterceptor.class);


### PR DESCRIPTION
ProtobufJsonProvider and Jersey's auto-registered
DefaultJacksonJaxbJsonProvider both declare MessageBodyWriter<Object> for application/json, so Jersey's WorkerComparator ties on type distance, media type distance and the custom flag alike, and the winner is whichever comes first in an unordered provider set. Agate happened to sort the protobuf provider first, but the order shifts with the set of scanned classes; when Jackson wins, writing any protobuf DTO fails with "Direct self-reference leading to cycle" on UnknownFieldSet, as it did in Mica.

Register AgateJacksonJsonProvider instead, a DefaultJacksonJaxbJsonProvider that declines protobuf messages and collections of them, so the choice no longer depends on provider order. JacksonFeature's own provider is opted out via InternalProperties.JSON_FEATURE; its two exception mappers are registered explicitly to keep the previous behaviour on malformed JSON.

The explicit ProtobufJsonProvider/ProtobufNativeProvider registrations are dropped: package scanning already finds them, and being registered does not make them win the tie the previous comment described.