### PR TITLE
fix: sign the OIDC ID tokens with RS256 so that clients can verify them

### DIFF
--- a/agate-core/src/main/java/org/obiba/agate/oidc/OIDCConfigurationFilter.java
+++ b/agate-core/src/main/java/org/obiba/agate/oidc/OIDCConfigurationFilter.java
@@ -56,7 +56,7 @@ public class OIDCConfigurationFilter extends OncePerRequestFilter {
     oidcConfig.put("end_session_endpoint", baseURL + "/ws/oauth2/logout");
     oidcConfig.put("userinfo_endpoint", baseURL + "/ws/oauth2/userinfo");
     oidcConfig.put("scopes_supported", new String[]{"openid", "email", "profile"});
-    oidcConfig.put("id_token_signing_alg_values_supported", new String[]{tokenUtils.getSignatureAlgorithm()});
+    oidcConfig.put("id_token_signing_alg_values_supported", new String[]{tokenUtils.getIDTokenSignatureAlgorithm()});
     oidcConfig.put("response_types_supported", new String[]{"code"});
     oidcConfig.put("subject_types_supported", new String[]{"public"});
     oidcConfig.put("jwks_uri", baseURL + "/ws/oauth2/certs");

--- a/agate-core/src/main/java/org/obiba/agate/service/KeyStoreService.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/KeyStoreService.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.security.KeyPair;
 import java.security.KeyStoreException;
 import java.security.cert.Certificate;
 import java.util.Optional;
@@ -31,6 +32,11 @@ import java.util.Optional;
 public class KeyStoreService implements InitializingBean {
 
   public static final String SYSTEM_KEY_STORE = "system";
+
+  /**
+   * Alias, in the system key store, of the key pair used to sign the OpenID Connect ID tokens.
+   */
+  public static final String OIDC_KEY_ALIAS = "oidc";
 
   private static final String PATH_KEYSTORE = "${AGATE_HOME}/data/keystores";
 
@@ -107,6 +113,24 @@ public class KeyStoreService implements InitializingBean {
     ksm.importKey(alias, new ByteArrayInputStream(privateKey.getBytes()),
       new ByteArrayInputStream(publicCertificate.getBytes()));
     saveKeyStore(ksm);
+  }
+
+  /**
+   * Get the key pair used to sign the OpenID Connect ID tokens, generating a self-signed one on first use. The public
+   * key is published as a JSON Web Key so that any OIDC client can verify the ID tokens.
+   *
+   * @return the OIDC signing key pair
+   */
+  @Nonnull
+  public synchronized KeyPair getOrCreateOIDCKeyPair() {
+    KeyStoreManager ksm = getSystemKeyStore();
+    if (!ksm.hasKeyPair(OIDC_KEY_ALIAS)) {
+      String hostname = Optional.ofNullable(configurationService.getConfiguration().getDomain()).orElse("localhost");
+      ksm.createOrUpdateKey(OIDC_KEY_ALIAS, "RSA", 2048,
+        String.format("CN=%s, OU=agate, O=%s, L=, ST=, C=", hostname, hostname));
+      saveKeyStore(ksm);
+    }
+    return ksm.getKeyPair(OIDC_KEY_ALIAS);
   }
 
   public void deleteKeyPair(String name, String alias) {

--- a/agate-core/src/main/java/org/obiba/agate/service/TokenUtils.java
+++ b/agate-core/src/main/java/org/obiba/agate/service/TokenUtils.java
@@ -14,7 +14,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.jsonwebtoken.*;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.Jwks;
+import io.jsonwebtoken.security.RsaPublicJwk;
 import jakarta.annotation.Nonnull;
 import org.joda.time.DateTime;
 import org.obiba.agate.domain.Authorization;
@@ -23,6 +24,8 @@ import org.obiba.agate.domain.User;
 import org.springframework.stereotype.Component;
 
 import jakarta.inject.Inject;
+import java.security.KeyPair;
+import java.security.interfaces.RSAPublicKey;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,6 +68,9 @@ public class TokenUtils {
   @Inject
   private ConfigurationService configurationService;
 
+  @Inject
+  private KeyStoreService keyStoreService;
+
   /**
    * Make an access token (json web token) for the ticket.
    *
@@ -101,8 +107,33 @@ public class TokenUtils {
         .compact();
   }
 
+  /**
+   * The algorithm used to sign the access tokens, which are only verified by Agate itself.
+   *
+   * @return
+   */
   public String getSignatureAlgorithm() {
     return SignatureAlgorithm.HS256.name();
+  }
+
+  /**
+   * The algorithm used to sign the ID tokens. As opposed to the access tokens, the ID tokens are verified by the OIDC
+   * clients, which cannot share a symmetric key with Agate: they are signed with a private key, the matching public key
+   * being published as a JSON Web Key.
+   *
+   * @return
+   */
+  public String getIDTokenSignatureAlgorithm() {
+    return Jwts.SIG.RS256.getId();
+  }
+
+  /**
+   * The public JSON Web Key to be used by the OIDC clients to verify the ID tokens, as published by the JWKS endpoint.
+   *
+   * @return the JWK, as a JSON object string
+   */
+  public String getIDTokenPublicJwk() {
+    return Jwks.json(makeIDTokenPublicJwk(keyStoreService.getOrCreateOIDCKeyPair()));
   }
 
   /**
@@ -143,9 +174,11 @@ public class TokenUtils {
     claims.add(Claims.AUDIENCE, authorization.getApplication());
     if (authorization.hasNonce()) claims.add("nonce", authorization.getNonce());
 
+    KeyPair keyPair = keyStoreService.getOrCreateOIDCKeyPair();
     return Jwts.builder()
+        .header().keyId(makeIDTokenPublicJwk(keyPair).getId()).and()
         .claims(claims.build())
-        .signWith(configurationService.getSecretKeyJWT())
+        .signWith(keyPair.getPrivate(), Jwts.SIG.RS256)
         .compact();
   }
 
@@ -172,6 +205,20 @@ public class TokenUtils {
   // Private methods
   //
 
+  /**
+   * Describe the public part of the ID token signing key pair as a JSON Web Key, the key ID being derived from the key
+   * itself so that it stays stable as long as the key pair is not renewed.
+   *
+   * @param keyPair
+   * @return
+   */
+  private RsaPublicJwk makeIDTokenPublicJwk(KeyPair keyPair) {
+    return Jwks.builder().key((RSAPublicKey) keyPair.getPublic())
+        .algorithm(getIDTokenSignatureAlgorithm())
+        .publicKeyUse("sig")
+        .idFromThumbprint()
+        .build();
+  }
 
   /**
    * The context of the token contains some custom entries about the user and the scope of the authorization (if any).

--- a/agate-core/src/test/java/org/obiba/agate/service/TokenUtilsTest.java
+++ b/agate-core/src/test/java/org/obiba/agate/service/TokenUtilsTest.java
@@ -1,0 +1,125 @@
+package org.obiba.agate.service;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
+import com.google.common.collect.Sets;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.obiba.agate.domain.Authorization;
+import org.obiba.agate.domain.User;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * The ID token is verified by the OIDC clients: check that what is signed can be validated with the public key that is
+ * published by the JWKS endpoint, using the same validator as the clients (nimbus).
+ */
+class TokenUtilsTest {
+
+  private static final String ISSUER = "https://agate.example.org";
+
+  private static final String APPLICATION = "opal";
+
+  @Mock
+  private UserService userService;
+
+  @Mock
+  private AuthorizationService authorizationService;
+
+  @Mock
+  private ConfigurationService configurationService;
+
+  @Mock
+  private KeyStoreService keyStoreService;
+
+  @InjectMocks
+  private TokenUtils tokenUtils;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+    generator.initialize(2048);
+    KeyPair keyPair = generator.generateKeyPair();
+    when(keyStoreService.getOrCreateOIDCKeyPair()).thenReturn(keyPair);
+    when(configurationService.getPublicUrl()).thenReturn(ISSUER);
+  }
+
+  @Test
+  void testIDTokenIsValidatedWithThePublishedJwk() throws Exception {
+    Authorization authorization = makeAuthorization("a-nonce");
+    String idToken = tokenUtils.makeIDToken(authorization, List.of());
+
+    IDTokenClaimsSet claims = validate(idToken, new Nonce("a-nonce"));
+
+    assertEquals(ISSUER, claims.getIssuer().getValue());
+    assertEquals("joe", claims.getSubject().getValue());
+    assertEquals(List.of(new com.nimbusds.oauth2.sdk.id.Audience(APPLICATION)), claims.getAudience());
+  }
+
+  @Test
+  void testIDTokenIsSignedWithRS256AndAdvertisedKeyId() throws Exception {
+    String idToken = tokenUtils.makeIDToken(makeAuthorization(null), List.of());
+
+    assertEquals(JWSAlgorithm.RS256, JWTParser.parse(idToken).getHeader().getAlgorithm());
+    assertEquals("RS256", tokenUtils.getIDTokenSignatureAlgorithm());
+    assertEquals(publishedJwkSet().getKeys().get(0).getKeyID(),
+        JWTParser.parse(idToken).getHeader().toJSONObject().get("kid"));
+  }
+
+  @Test
+  void testPublishedJwkHasNoPrivateKeyMaterial() throws Exception {
+    assertFalse(publishedJwkSet().getKeys().get(0).isPrivate());
+    assertEquals("sig", publishedJwkSet().getKeys().get(0).getKeyUse().identifier());
+  }
+
+  @Test
+  void testIDTokenIsRejectedWhenNonceDoesNotMatch() {
+    String idToken = tokenUtils.makeIDToken(makeAuthorization("a-nonce"), List.of());
+
+    assertThrows(Exception.class, () -> validate(idToken, new Nonce("another-nonce")));
+  }
+
+  @Test
+  void testNoIDTokenWithoutOpenIdScope() {
+    Authorization authorization = new Authorization("joe", APPLICATION);
+    authorization.setScopes(Sets.newHashSet("opal:read"));
+
+    assertEquals("", tokenUtils.makeIDToken(authorization, List.of()));
+  }
+
+  private IDTokenClaimsSet validate(String idToken, Nonce nonce) throws Exception {
+    IDTokenValidator validator = new IDTokenValidator(new Issuer(ISSUER), new ClientID(APPLICATION),
+        JWSAlgorithm.RS256, publishedJwkSet());
+    return validator.validate(JWTParser.parse(idToken), nonce);
+  }
+
+  private JWKSet publishedJwkSet() throws Exception {
+    return JWKSet.parse("{\"keys\":[" + tokenUtils.getIDTokenPublicJwk() + "]}");
+  }
+
+  private Authorization makeAuthorization(String nonce) {
+    Authorization authorization = new Authorization("joe", APPLICATION);
+    authorization.setScopes(Sets.newHashSet(TokenUtils.OPENID_SCOPE));
+    authorization.setCreatedDate(DateTime.now());
+    authorization.setNonce(nonce);
+    when(userService.findUser("joe")).thenReturn(new User("joe", "agate-user-realm"));
+    when(authorizationService.getExpirationDate(authorization)).thenReturn(DateTime.now().plusHours(1));
+    return authorization;
+  }
+}

--- a/agate-rest/src/main/java/org/obiba/agate/web/rest/ticket/OAuthResource.java
+++ b/agate-rest/src/main/java/org/obiba/agate/web/rest/ticket/OAuthResource.java
@@ -29,6 +29,7 @@ import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.apache.shiro.subject.Subject;
 import org.joda.time.DateTime;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.obiba.agate.domain.Application;
@@ -151,7 +152,7 @@ public class OAuthResource {
   @Produces("application/json")
   public Response certs(@Context HttpServletRequest servletRequest) throws JSONException {
     JSONObject jwks = new JSONObject();
-    jwks.put("keys", new String[]{});
+    jwks.put("keys", new JSONArray().put(new JSONObject(tokenUtils.getIDTokenPublicJwk())));
     return Response.ok(jwks.toString(2)).build();
   }
 


### PR DESCRIPTION
The ID tokens were signed with HS256 using the server-wide JWT secret key, which no client knows: the OIDC clients verify HS256 ID tokens with their client secret, so the signature could never be validated. Agate cannot sign with the client secret either, as only a hash of the application key is stored.

Sign the ID tokens with a dedicated RSA key pair instead, kept in the system key store under the "oidc" alias and generated on first use, and publish the matching public key as a JSON Web Key at the JWKS endpoint, which until now returned an empty key set. The discovery document advertises RS256 for the ID tokens accordingly.

The access tokens are only verified by Agate itself and keep being signed with the JWT secret key.